### PR TITLE
Revert "Update Helm release tailscale-operator to v1.78.3"

### DIFF
--- a/k8s/flux/infra/network/tailscale-operator.yaml
+++ b/k8s/flux/infra/network/tailscale-operator.yaml
@@ -18,7 +18,7 @@ spec:
         kind: HelmRepository
         name: tailscale
         namespace: flux-system
-      version: "1.78.3"
+      version: "1.78.1"
   interval: 1h
   install:
     remediation:


### PR DESCRIPTION
Reverts emerconn/fleet-infra#175